### PR TITLE
Stronger Type Definition for Dino Ipsum

### DIFF
--- a/packages/DinoIpsum/lib/DinoIpsum.ts
+++ b/packages/DinoIpsum/lib/DinoIpsum.ts
@@ -1,4 +1,3 @@
-import { AxiosPromise, AxiosResponse } from 'axios';
 import { find } from './services/base.req';
 
 type FormatString = 'text' | 'json' | 'html';

--- a/packages/DinoIpsum/lib/DinoIpsum.ts
+++ b/packages/DinoIpsum/lib/DinoIpsum.ts
@@ -2,8 +2,7 @@ import { AxiosPromise, AxiosResponse } from 'axios';
 import { find } from './services/base.req';
 
 type FormatString = 'text' | 'json' | 'html';
-interface QueryParams
-{
+interface QueryParams {
   format: FormatString;
   paragraphs: number;
   words: number;
@@ -13,7 +12,7 @@ export class DinoIpsum {
   private baseURL = 'http://dinoipsum.herokuapp.com/api/';
 
   public async getDinoIpsum(
-    format:FormatString = 'json',
+    format: FormatString = 'json',
     paragraphs = 10,
     words = 30,
   ): Promise<any> {

--- a/packages/DinoIpsum/lib/DinoIpsum.ts
+++ b/packages/DinoIpsum/lib/DinoIpsum.ts
@@ -1,21 +1,24 @@
 import { AxiosPromise, AxiosResponse } from 'axios';
 import { find } from './services/base.req';
 
+type FormatString = 'text' | 'json' | 'html';
+interface QueryParams
+{
+  format: FormatString;
+  paragraphs: number;
+  words: number;
+}
+
 export class DinoIpsum {
   private baseURL = 'http://dinoipsum.herokuapp.com/api/';
 
   public async getDinoIpsum(
-    format = 'json',
+    format:FormatString = 'json',
     paragraphs = 10,
     words = 30,
   ): Promise<any> {
-    format = format.toLowerCase();
-    if (format != 'json' && format != 'html' && format != 'text') {
-      format = 'json';
-    }
-
     const url: string = this.getBaseURL();
-    const params: any = {
+    const params: QueryParams = {
       format,
       paragraphs,
       words,

--- a/packages/DinoIpsum/tests/DinoIpsum.test.ts
+++ b/packages/DinoIpsum/tests/DinoIpsum.test.ts
@@ -32,17 +32,6 @@ describe('DinoIpsum', () => {
     expect(resultArray.length).toBeGreaterThan(expectedWordCount);
   });
 
-  test('should return with JSON data if a string not of json, text, or html is submitted', async () => {
-    const result = await dinoIpsum.getDinoIpsum('testtestest');
-
-    const expectedParagraphCount = 10;
-    const expectedWordCount = 30;
-
-    expect(result.status).toBe(200);
-    expect(result.data.length).toEqual(expectedParagraphCount);
-    expect(result.data[0].length).toEqual(expectedWordCount);
-  });
-
   test('should return with JSON Dino Ipsum in a custom paragraph and word count', async () => {
     const result = await dinoIpsum.getDinoIpsum('JSON', 4, 250);
 

--- a/packages/DinoIpsum/tests/DinoIpsum.test.ts
+++ b/packages/DinoIpsum/tests/DinoIpsum.test.ts
@@ -33,7 +33,7 @@ describe('DinoIpsum', () => {
   });
 
   test('should return with JSON Dino Ipsum in a custom paragraph and word count', async () => {
-    const result = await dinoIpsum.getDinoIpsum('JSON', 4, 250);
+    const result = await dinoIpsum.getDinoIpsum('json', 4, 250);
 
     const expectedParagraphCount = 4;
     const expectedWordCount = 250;


### PR DESCRIPTION
add stronger type definitions for DinoIpsum.ts. Removes unecessary test and code for edge case where non standard format string was submitted. This is now addressed by the FormatString type.

Now when calling DinoIpsum. getDinoIpsum() stronger  type definitions are used. Strings that are not 'html', 'json', or 'text' will be rejected. 

This update also implements a QueryParams interface for the method parameters.

Additionally removes unecessary test for edge cases where non-standard format string is submitted. 